### PR TITLE
Add fallback method for `lplot!`

### DIFF
--- a/ext/recipes/lplot.jl
+++ b/ext/recipes/lplot.jl
@@ -207,3 +207,28 @@ function LegendMakie.lplot!(
 
     fig
 end
+
+
+function LegendMakie.lplot!(args...; watermark::Bool = false, kwargs...)
+
+    fig = Makie.current_figure()
+
+    #create plot
+    ax = if !isnothing(Makie.current_axis())
+        Makie.current_axis()
+    else
+        Makie.Axis(fig[1,1],
+            titlesize = 18,
+            titlegap = 1,
+            titlealign = :right
+        )
+    end
+
+    # use built-in method as fallback if existent, tweak appearance
+    Makie.plot!(args...; kwargs...)
+
+    # add watermarks
+    watermark && LegendMakie.add_watermarks!(; kwargs...)
+
+    fig
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,6 +5,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LegendSpecFits = "18221496-77af-46cf-bab8-820da09f7f97"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 RadiationDetectorSignals = "bf2c0563-65cf-5db2-a620-ceb7de82658c"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -5,6 +5,7 @@ using Makie
 
 import LegendSpecFits
 import Distributions
+import StatsBase
 import Unitful: @u_str
 
 using Test
@@ -16,7 +17,7 @@ using Test
 
         # test default watermark
         ax = Axis(fig[1,1])
-        hist!(ax, randn(10000))
+        @test_nowarn lplot!(StatsBase.fit(StatsBase.Histogram, randn(10000)))
         @test_nowarn LegendMakie.add_watermarks!()
 
         # test alternative watermark


### PR DESCRIPTION
Added an `lplot!` method that falls back to `Makie.plot!` but tweaks the appearance.

For example:
```julia
using LegendMakie, CairoMakie
using StatsBase

lplot(fit(Histogram, randn(10000)))
```
![image](https://github.com/user-attachments/assets/a58b60cb-c9fd-429f-a8ab-197f8ef59ae4)

