### PR TITLE
Add `lplot!` for A/E ctc plot

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
+KernelDensity = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LegendDataManagement = "9feedd95-f0e0-423f-a8dc-de0970eae6b3"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
@@ -21,7 +22,7 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
-LegendMakieExt = ["Makie", "Dates", "FileIO", "Format", "LaTeXStrings", "MathTeXEngine", "StatsBase", "Unitful"]
+LegendMakieExt = ["Makie", "Dates", "FileIO", "Format", "KernelDensity", "LaTeXStrings", "MathTeXEngine", "StatsBase", "Unitful"]
 LegendMakieLegendDataManagementExt = ["Makie", "LegendDataManagement", "Format", "Measurements", "PropDicts", "TypedTables", "Unitful"]
 LegendMakieMeasurementsExt = ["Makie", "LaTeXStrings", "Measurements"]
 LegendMakieRadiationDetectorSignalsExt = "RadiationDetectorSignals"
@@ -30,6 +31,7 @@ LegendMakieRadiationDetectorSignalsExt = "RadiationDetectorSignals"
 Dates = "1"
 FileIO = "1"
 Format = "1"
+KernelDensity = "0.6"
 LaTeXStrings = "1.2"
 LegendDataManagement = "0.4"
 Makie = "0.22"

--- a/ext/LegendMakieExt.jl
+++ b/ext/LegendMakieExt.jl
@@ -7,6 +7,7 @@ module LegendMakieExt
     import Dates
     import FileIO
     import Format
+    import KernelDensity
     import LaTeXStrings
     import Makie
     import MathTeXEngine

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -77,6 +77,16 @@ using Test
             @test_nowarn lplot(report_cut, figsize = (750,400), title = "Test")
         end
 
+        @testset "A/E ctc correlation plot" begin
+            # generate fake A/E and Qdrift/E distribution 
+            E0 = 550u"keV"
+            e_cal = fill(E0, 10_000)
+            aoe_corr = vcat(-rand(Distributions.Exponential(5.0), 2_000), zeros(8_000)) .+ randn(10_000)
+            qdrift_e = max.(0, randn(10_000) .+ 5)
+            result_aoe_ctc, report_aoe_ctc = LegendSpecFits.ctc_aoe(aoe_corr, e_cal, qdrift_e, [E0])
+            lplot(report_aoe_ctc, figsize = (600,600))
+        end
+
         @testset "Parameter plots" begin
             l200 = LegendDataManagement.LegendData(:l200)
             filekey = LegendDataManagement.start_filekey(l200, :p02, :r000, :cal)


### PR DESCRIPTION
This requires https://github.com/legend-exp/LegendSpecFits.jl/pull/121 to be merged first.

```julia
result_aoe_ctc, report_aoe_ctc = LegendSpecFits.ctc_aoe(aoe_corr, e_cal, qdrift_e, compton_bands,
    aoe_expression = result_correction.func, qdrift_expression = qdrift_expression)
lplot(report_aoe_ctc, figsize = (600,600))
```
![image](https://github.com/user-attachments/assets/bc73150f-3a40-408b-9078-35c1a09a5255)

