### PR TITLE
Add `lplot!` for simple energy calibration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
 KernelDensity = "5ab0869b-81aa-558d-bb23-cbf5423bbe9b"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LegendDataManagement = "9feedd95-f0e0-423f-a8dc-de0970eae6b3"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 MathTeXEngine = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
@@ -22,7 +23,7 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
-LegendMakieExt = ["Makie", "Dates", "FileIO", "Format", "KernelDensity", "LaTeXStrings", "MathTeXEngine", "StatsBase", "Unitful"]
+LegendMakieExt = ["Makie", "Dates", "FileIO", "Format", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MathTeXEngine", "StatsBase", "Unitful"]
 LegendMakieLegendDataManagementExt = ["Makie", "LegendDataManagement", "Format", "Measurements", "PropDicts", "TypedTables", "Unitful"]
 LegendMakieMeasurementsExt = ["Makie", "LaTeXStrings", "Measurements"]
 LegendMakieRadiationDetectorSignalsExt = "RadiationDetectorSignals"
@@ -34,6 +35,7 @@ Format = "1"
 KernelDensity = "0.6"
 LaTeXStrings = "1.2"
 LegendDataManagement = "0.4"
+LinearAlgebra = "1"
 Makie = "0.22"
 MakieCore = "0.9"
 MathTeXEngine = "0.6.1"

--- a/ext/LegendMakieExt.jl
+++ b/ext/LegendMakieExt.jl
@@ -9,6 +9,7 @@ module LegendMakieExt
     import Format
     import KernelDensity
     import LaTeXStrings
+    import LinearAlgebra
     import Makie
     import MathTeXEngine
     import StatsBase

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -88,9 +88,10 @@ using Test
             # generate fake A/E and Qdrift/E distribution 
             E0 = 550u"keV"
             e_cal = fill(E0, 10_000)
-            aoe_corr = vcat(-rand(Distributions.Exponential(5.0), 2_000), zeros(8_000)) .+ randn(10_000)
+            aoe_corr = clamp.(vcat(-rand(Distributions.Exponential(5.0), 2_000), zeros(8_000)) .+ randn(10_000), -49.0, 7.0)
             qdrift_e = max.(0, randn(10_000) .+ 5)
-            result_aoe_ctc, report_aoe_ctc = LegendSpecFits.ctc_aoe(aoe_corr, e_cal, qdrift_e, [E0])
+            @test length(e_cal) == length(aoe_corr) == length(qdrift_e) == 10_000
+            result_aoe_ctc, report_aoe_ctc = LegendSpecFits.ctc_aoe(aoe_corr, e_cal, qdrift_e, [E0-10u"keV"])
             @test_nowarn lplot(report_aoe_ctc, figsize = (600,600))
         end
 

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -38,6 +38,13 @@ using Test
             @test_nowarn lplot(report, xlabel = "x")
         end
 
+        @testset "Simple energy calibration" begin
+            ecal = vcat(rand(Distributions.Exponential(40_000),90_000), 261_450 .+ 1_000 .* randn(1_000))
+            _, report_simple = LegendSpecFits.simple_calibration(ecal, [2614.511u"keV"], [35u"keV"], [30u"keV"], calib_type = :th228)
+            @test_nowarn lplot(report_simple)
+            @test_nowarn lplot(report_simple, cal = false)
+        end
+
         @testset "A/E correction" begin
             # generate fake A/E distribution
             e_cal = rand(Distributions.Exponential(300), 5_000_000) .+ 300


### PR DESCRIPTION
Plot recipe for the report returned by `LegendSpecFits.simple_calibration`:
```julia
result_simple, report_simple = simple_calibration(e_uncal, energy_config_ch.th228_lines,
    energy_config_ch.left_window_sizes, energy_config_ch.right_window_sizes, calib_type=:th228)

LegendMakie.lplot(report_simple, title = get_plottitle(filekey, det, "Simple Calibration"; additiional_type=string(e_type)))
LegendMakie.lplot(report_simple, title = get_plottitle(filekey, det, "Simple Calibration"; additiional_type=string(e_type)), cal = false)
```
![image](https://github.com/user-attachments/assets/642ff2d4-e9e2-478f-89e5-fb851f70df36)
![image](https://github.com/user-attachments/assets/1afef136-f9b0-4069-bc1e-350918b3e4ea)
