### PR TITLE
Add `lplot!` for `Dict{Symbol, NamedTuple}`

### DIFF
--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -38,11 +38,18 @@ using Test
             @test_nowarn lplot(report, xlabel = "x")
         end
 
-        @testset "Simple energy calibration" begin
-            ecal = vcat(rand(Distributions.Exponential(40_000),90_000), 261_450 .+ 1_000 .* randn(1_000))
-            _, report_simple = LegendSpecFits.simple_calibration(ecal, [2614.511u"keV"], [35u"keV"], [30u"keV"], calib_type = :th228)
-            @test_nowarn lplot(report_simple)
-            @test_nowarn lplot(report_simple, cal = false)
+        @testset "Energy calibration" begin
+            ecal = vcat(rand(Distributions.Exponential(50_000),97_500), 261_450 .+ 200 .* randn(2_000), 210_350 .+ 150 .* randn(300), 159_300 .+ 100 .* randn(200))
+            result_simple, report_simple = LegendSpecFits.simple_calibration(ecal, [1592.513, 2103.512, 2614.511]u"keV", [25, 25, 35]u"keV", [25, 25, 30]u"keV", calib_type = :th228)
+            @testset "Simple energy calibration" begin
+                @test_nowarn lplot(report_simple)
+                @test_nowarn lplot(report_simple, cal = false)
+            end
+            m_cal_simple = result_simple.c
+            result_fit, report_fit = LegendSpecFits.fit_peaks(result_simple.peakhists, result_simple.peakstats, [:Tl208DEP, :Tl208SEP, :Tl208FEP]; e_unit=result_simple.unit, calib_type=:th228, m_cal_simple=m_cal_simple)
+            @testset "Fit energy calibration" begin
+                @test_nowarn lplot(report_fit, figsize = (600, 400*length(report_fit)), title = "Test title")
+            end
         end
 
         @testset "A/E correction" begin


### PR DESCRIPTION
Some functions in `LegendSpecFits` return a dictionary of reports, for example `LegendSpecFits.fit_peaks`.

This PR adds a plot recipe to create a plot from the individual reports but still provides a title etc.
I also modified the plot recipe for histogram fits with custom components.

```julia
result_fit, report_fit = LegendSpecFits.fit_peaks(result_simple.peakhists, result_simple.peakstats, th228_names;
    e_unit=result_simple.unit, calib_type=:th228, m_cal_simple=m_cal_simple)

LegendMakie.lplot(report_fit, figsize = (600, 400*length(report_fit)), 
    title = get_plottitle(filekey, det, "Peak Fits"; additiional_type=string(e_type)))
```
![image](https://github.com/user-attachments/assets/8029930d-2739-4986-b103-6258a94b84b8)

It is not so easy for this plot to prevent the legend to clash with the histogram or fit lines.
One could adjust the plot recipe of the histogram fit such that the background line is always plotted in the lowest 20%. However, this only works, if there is a "flat" background component.