### PR TITLE
Add `energycalibrationplot` and `lplot!` for energy calibration plots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [extensions]
 LegendMakieExt = ["Makie", "Dates", "FileIO", "Format", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MathTeXEngine", "StatsBase", "Unitful"]
 LegendMakieLegendDataManagementExt = ["Makie", "LegendDataManagement", "Format", "Measurements", "PropDicts", "TypedTables", "Unitful"]
-LegendMakieMeasurementsExt = ["Makie", "LaTeXStrings", "Measurements"]
+LegendMakieMeasurementsExt = ["Makie", "LaTeXStrings", "Measurements", "Unitful"]
 LegendMakieRadiationDetectorSignalsExt = "RadiationDetectorSignals"
 
 [compat]

--- a/ext/LegendMakieMeasurementsExt.jl
+++ b/ext/LegendMakieMeasurementsExt.jl
@@ -7,8 +7,18 @@ module LegendMakieMeasurementsExt
     import LaTeXStrings
     import Makie
     import Measurements
+    import Unitful
 
-    import LegendMakie: pt, aoecorrectionplot!
+    import LegendMakie: pt, aoecorrectionplot!, energycalibrationplot!
+
+    # function to compose labels when errorbars are scaled
+    function label_errscaling(xerrscaling::Real, yerrscaling::Real)
+        result = String[]
+        xerrscaling != 1 && push!(result, "x-Error ×$(xerrscaling)")
+        yerrscaling != 1 && push!(result, "y-Error ×$(yerrscaling)")
+        isempty(result) ? "" : " ($(join(result,", ")))"
+    end
+
 
     Makie.@recipe(AoECorrectionPlot, report) do scene
         Makie.Attributes(
@@ -28,6 +38,58 @@ module LegendMakieMeasurementsExt
         Makie.lines!(p, 0:1:3000, report.f_fit ∘ Measurements.value, color = p.color, label = LaTeXStrings.latexstring("\\fontfamily{Roboto}" * report.label_fit))
         Makie.errorbars!(p, report.x, Measurements.value.(report.y), Measurements.uncertainty.(report.y), color = p.markercolor)
         Makie.scatter!(p, report.x, Measurements.value.(report.y), color = p.markercolor, label = "Compton band fits: Gaussian $(report.label_y)(A/E)")
+        p
+    end
+
+
+    Makie.@recipe(EnergyCalibrationPlot, report, additional_pts) do scene
+        Makie.Attributes(
+            color = LegendMakie.AchatBlue,
+            plot_ribbon = true,
+            xerrscaling = 1,
+            yerrscaling = 1
+        )
+    end
+
+    # Needed for creatings legend using Makie recipes
+    # https://discourse.julialang.org/t/makie-defining-legend-output-for-a-makie-recipe/121567
+    function Makie.get_plots(p::EnergyCalibrationPlot)
+        return p.plots
+    end
+    
+    function Makie.plot!(p::EnergyCalibrationPlot{<:Tuple{<:NamedTuple{(:par, :f_fit, :x, :y, :gof)}, <:NamedTuple}})
+        
+        report = p.report[]
+        additional_pts = p.additional_pts[]
+        xerrscaling = p.xerrscaling[]
+        yerrscaling = p.yerrscaling[]
+
+        # plot fit
+        xfit = 0:1:1.2*Measurements.value(maximum(report.x))
+        yfit = report.f_fit.(xfit)
+        yfit_m = Measurements.value.(yfit)
+        Makie.lines!(xfit, yfit_m, label = "Best Fit" * (!isempty(report.gof) ? " (p = $(round(report.gof.pvalue, digits=2))| χ²/ndf = $(round(report.gof.chi2min, digits=2)) / $(report.gof.dof))" : ""), color = p.color)
+        if p.plot_ribbon[]
+            Δyfit = Measurements.uncertainty.(yfit)
+            Makie.band!(xfit, yfit_m .- Δyfit, yfit_m .+ Δyfit, color = (p.color[], 0.2))
+        end
+        
+        # scatter points with error bars
+        xvalues = Measurements.value.(report.x)
+        yvalues = Measurements.value.(report.y)
+        Makie.errorbars!(p, xvalues, yvalues, Measurements.uncertainty.(report.x) .* xerrscaling, direction = :x, color = :black)
+        Makie.errorbars!(p, xvalues, yvalues, Measurements.uncertainty.(report.y) .* yerrscaling, color = :black)
+        Makie.scatter!(p, xvalues, yvalues, marker = :circle, color = :black, label = "Data" * label_errscaling(xerrscaling, yerrscaling))
+        
+        # plot additional points
+        if !isempty(additional_pts)
+            xvalues = Measurements.value.(additional_pts.x)
+            yvalues = Measurements.value.(additional_pts.y)
+            Makie.errorbars!(p, xvalues, yvalues, Measurements.uncertainty.(additional_pts.x) .* xerrscaling, direction = :x, color = :black)
+            Makie.errorbars!(p, xvalues, yvalues, Measurements.uncertainty.(additional_pts.y) .* yerrscaling, color = :black)
+            Makie.scatter!(p, xvalues, yvalues, marker = :circle, color = :silver, strokewidth = 1, strokecolor = :black, label = "Data not used for fit" * label_errscaling(xerrscaling, yerrscaling))
+        end
+
         p
     end
 

--- a/ext/recipes/lplot.jl
+++ b/ext/recipes/lplot.jl
@@ -367,6 +367,8 @@ end
 # fallback method: use Makie.plot!
 function LegendMakie.lplot!(args...; watermark::Bool = false, kwargs...)
 
+    @info "No `LegendMakie` plot recipe found for this set of arguments. Using `Makie.plot!`"
+
     fig = Makie.current_figure()
     ax = isnothing(Makie.current_axis()) ? Makie.Axis(fig[1,1]) : Makie.current_axis()
 

--- a/src/lplot.jl
+++ b/src/lplot.jl
@@ -25,6 +25,7 @@ export lsavefig
 
 # recipes
 function residualplot! end
+function energycalibrationplot! end
 function aoecorrectionplot! end
 function parameterplot! end
 

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -23,7 +23,7 @@ using Test
 
         # test default watermark
         ax = Axis(fig[1,1])
-        @test_nowarn lplot!(StatsBase.fit(StatsBase.Histogram, randn(10000)))
+        lplot!(StatsBase.fit(StatsBase.Histogram, randn(10000)))
         @test_nowarn LegendMakie.add_watermarks!()
 
         # test alternative watermark

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -39,7 +39,7 @@ using Test
         end
 
         @testset "Energy calibration" begin
-            ecal = filter(x -> x <= 262_000, vcat(rand(Distributions.Exponential(70_000),97_500), 261_450 .+ 200 .* randn(2_000), 210_350 .+ 150 .* randn(300), 159_300 .+ 100 .* randn(200)))
+            ecal = filter(x -> x <= 265_000, vcat(rand(Distributions.Exponential(70_000),97_000), 261_450 .+ 200 .* randn(2_000), 210_350 .+ 185 .* randn(500), 159_300 .+ 170 .* randn(500)))
             lines = [:Tl208DEP, :Tl208SEP, :Tl208FEP]
             energies = [1592.513, 2103.512, 2614.511]u"keV"
             result_simple, report_simple = LegendSpecFits.simple_calibration(ecal, energies, [25, 25, 35]u"keV", [25, 25, 30]u"keV", calib_type = :th228)
@@ -56,6 +56,12 @@ using Test
             result_calib, report_calib = LegendSpecFits.fit_calibration(1, μ_fit, energies)
             @testset "Fit energy calibration" begin
                 @test_nowarn lplot(report_calib, xerrscaling=10, yerrscaling=10, additional_pts=(μ = [100_000], peaks = [1000u"keV"]), title = "Test")
+            end
+            f_cal_widths(x) = report_calib.f_fit(x) .* report_calib.e_unit .- first(report_calib.par)
+            fwhm_fit = f_cal_widths.(getfield.(getindex.(Ref(result_fit), lines), :fwhm))
+            result_fwhm, report_fwhm = LegendSpecFits.fit_fwhm(1, energies, fwhm_fit, uncertainty=true)
+            @testset "FWHM energy calibration" begin
+                @test_nowarn lplot(report_fwhm, additional_pts=(peaks = [1000u"keV"], fwhm = [3.5u"keV"]), title = "Test")
             end
         end
 

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -39,16 +39,23 @@ using Test
         end
 
         @testset "Energy calibration" begin
-            ecal = vcat(rand(Distributions.Exponential(50_000),97_500), 261_450 .+ 200 .* randn(2_000), 210_350 .+ 150 .* randn(300), 159_300 .+ 100 .* randn(200))
-            result_simple, report_simple = LegendSpecFits.simple_calibration(ecal, [1592.513, 2103.512, 2614.511]u"keV", [25, 25, 35]u"keV", [25, 25, 30]u"keV", calib_type = :th228)
+            ecal = filter(x -> x <= 262_000, vcat(rand(Distributions.Exponential(70_000),97_500), 261_450 .+ 200 .* randn(2_000), 210_350 .+ 150 .* randn(300), 159_300 .+ 100 .* randn(200)))
+            lines = [:Tl208DEP, :Tl208SEP, :Tl208FEP]
+            energies = [1592.513, 2103.512, 2614.511]u"keV"
+            result_simple, report_simple = LegendSpecFits.simple_calibration(ecal, energies, [25, 25, 35]u"keV", [25, 25, 30]u"keV", calib_type = :th228)
             @testset "Simple energy calibration" begin
                 @test_nowarn lplot(report_simple)
                 @test_nowarn lplot(report_simple, cal = false)
             end
             m_cal_simple = result_simple.c
-            result_fit, report_fit = LegendSpecFits.fit_peaks(result_simple.peakhists, result_simple.peakstats, [:Tl208DEP, :Tl208SEP, :Tl208FEP]; e_unit=result_simple.unit, calib_type=:th228, m_cal_simple=m_cal_simple)
+            result_fit, report_fit = LegendSpecFits.fit_peaks(result_simple.peakhists, result_simple.peakstats, lines; e_unit=result_simple.unit, calib_type=:th228, m_cal_simple=m_cal_simple)
+            @testset "Fit peaks for energy calibration" begin
+                @test_nowarn lplot(report_fit, figsize = (600, 400*length(report_fit)), watermark = false)
+            end
+            μ_fit = getfield.(getindex.(Ref(result_fit), lines), :centroid)
+            result_calib, report_calib = LegendSpecFits.fit_calibration(1, μ_fit, energies)
             @testset "Fit energy calibration" begin
-                @test_nowarn lplot(report_fit, figsize = (600, 400*length(report_fit)), title = "Test title")
+                @test_nowarn lplot(report_calib, xerrscaling=10, yerrscaling=10, additional_pts=(μ = [100_000], peaks = [1000u"keV"]), title = "Test")
             end
         end
 


### PR DESCRIPTION
These functions can plot the report returned by `LegendSpecFits.fit_calibration`:

```julia
result_calib, report_calib = fit_calibration(energy_config_ch.cal_pol_order, μ_fit, pp_fit; e_expression=e_uncal_func)

LegendMakie.lplot(report_calib, xerrscaling=100, additional_pts=(μ = μ_notfit, peaks = pp_notfit), 
    title = get_plottitle(filekey, det, "Calibration Curve"; additiional_type=string(e_type)))
```
![image](https://github.com/user-attachments/assets/b627ed14-06d4-4143-9500-91c671a84364)

 
 I tried to allow for the same keywords (`plot_ribbon`, `xerrscaling`, `yerrscaling`) as before
