### PR TITLE
Improve default `xlims` for single fit reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,3 @@
 # comment: false
+ignore:
+  - "src/register_extdeps.jl"

--- a/ext/LegendMakieMeasurementsExt.jl
+++ b/ext/LegendMakieMeasurementsExt.jl
@@ -11,6 +11,13 @@ module LegendMakieMeasurementsExt
 
     import LegendMakie: pt, aoecorrectionplot!, energycalibrationplot!
 
+    # extends LegendMakie.default_xlims in LegendMakieExt.jl
+    # for the cases where μ and σ have uncertainties
+    function LegendMakie.default_xlims(report::NamedTuple{(:f_fit, :h, :μ, :σ, :gof),<:Tuple{Any,Any,M,M,Any}}
+        ) where {M <: Union{Measurements.Measurement, Unitful.Quantity{<:Measurements.Measurement}}}
+        Unitful.ustrip.(Measurements.value.((report.μ - 5*report.σ, report.μ + 5*report.σ)))
+    end
+
     # function to compose labels when errorbars are scaled
     function label_errscaling(xerrscaling::Real, yerrscaling::Real)
         result = String[]

--- a/ext/recipes/lplot.jl
+++ b/ext/recipes/lplot.jl
@@ -1,15 +1,20 @@
 # This file is a part of LegendMakie.jl, licensed under the MIT License (MIT).
 
-
 function round_wo_units(x::Unitful.RealOrRealQuantity; digits::Int=2)
     Unitful.unit(x) == Unitful.NoUnits ? round(x; digits) : round(Unitful.unit(x), x; digits)
 end
+
+function LegendMakie.default_xlims(report::NamedTuple{(:f_fit, :h, :μ, :σ, :gof)})
+    Unitful.ustrip.((report.μ - 5*report.σ, report.μ + 5*report.σ))
+end
+
 
 # single fits
 function LegendMakie.lplot!(
         report::NamedTuple{(:f_fit, :h, :μ, :σ, :gof)};
         title::AbstractString = "", show_residuals::Bool = true,
-        xlabel = "", xticks = Makie.automatic, xlims = nothing, ylims = (0,nothing),
+        ylims = (0,nothing), xlabel = "", xticks = Makie.automatic, 
+        xlims = LegendMakie.default_xlims(report), 
         legend_position = :lt, watermark::Bool = true, final::Bool = (title != ""), kwargs...
     )
 
@@ -24,7 +29,7 @@ function LegendMakie.lplot!(
     # Create histogram
     Makie.plot!(ax, report.h, label = "Data")
     
-    _x = range(extrema(first(report.h.edges))..., length = 1000)
+    _x = range(extrema(xlims)..., length = 1000)
     Makie.lines!(_x, report.f_fit.(_x), color = :red, 
         label = "Normal Fit\nμ = $(round_wo_units(report.μ, digits=2))\nσ = $(round_wo_units(report.σ, digits=2))")
     
@@ -56,7 +61,6 @@ function LegendMakie.lplot!(
     
     fig
 end
-
 
 function LegendMakie.lplot!(
         report::NamedTuple{(:v, :h, :f_fit, :f_components, :gof)};

--- a/src/lplot.jl
+++ b/src/lplot.jl
@@ -35,3 +35,6 @@ function add_legend_logo! end
 function add_juleana_logo! end
 function add_text! end
 function add_watermarks! end
+
+# auxiliary functions
+function default_xlims end

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -36,6 +36,9 @@ using Test
         @testset "Singlefits" begin
             result, report = LegendSpecFits.fit_single_trunc_gauss(randn(10000), (low = -4.0, high = 4.0, max = NaN))
             @test_nowarn lplot(report, xlabel = "x")
+
+            result, report = LegendSpecFits.fit_single_trunc_gauss(randn(10000), uncertainty = false)
+            @test_nowarn lplot(report, xlabel = "Test")
         end
 
         @testset "Energy calibration" begin


### PR DESCRIPTION
Just as in the old `Plots` recipe, the `xlims` are chosen as `±5σ` around the central value `µ` of the fit.
This becomes a bit tricky when `µ` and `σ` are of type `Measurements`.

In this PR, I added a new function `default_xlims` that handles this case without having to migrate the whole plot recipe into `LegendMakieMeasurementsExt.jl`.

This way, the new `Makie` plot is closer to the old `Plots` plot, e.g. for the decay time fits:

## Code example
```julia
# Generate report
decay_times = LegendDSP.dsp_decay_times(wvfs_ch, dsp_config_ch)
cuts_τ = LegendSpecFits.cut_single_peak(decay_times, min_τ, max_τ,; n_bins=nbins, relative_cut=rel_cut_fit)            
result, report = LegendSpecFits.fit_single_trunc_gauss(decay_times, cuts_τ)

# Plot report
LegendMakie.lplot(report, title = get_plottitle(filekey, det, "Decay Time Distribution"))
```
![image](https://github.com/user-attachments/assets/e0cff9d4-003b-4df3-9e0f-64ab647a8630)


```julia
# Plot report with old plot recipe
p = plot(report)
title!(p, get_plottitle(filekey, det, "Decay Time Distribution"), subplot=1)
```
![image](https://github.com/user-attachments/assets/ef7e5eee-7124-4d24-93dd-164b3bf73c4d)

