### PR TITLE
Add `lhist!` to plot 2D A/E histograms

### DIFF
--- a/ext/LegendMakieExt.jl
+++ b/ext/LegendMakieExt.jl
@@ -20,6 +20,7 @@ module LegendMakieExt
 
     include("recipes/recipes.jl")
     include("recipes/lplot.jl")
+    include("recipes/lhist.jl")
     include("recipes/watermarks.jl")
 
     function __init__()
@@ -43,6 +44,13 @@ module LegendMakieExt
         # create new Figure
         fig = Makie.Figure(size = figsize)
         LegendMakie.lplot!(args...; kwargs...)
+        fig
+    end
+
+    function LegendMakie.lhist(args...; figsize = Makie.theme(:size), kwargs...)
+        # create new Figure
+        fig = Makie.Figure(size = figsize)
+        LegendMakie.lhist!(args...; kwargs...)
         fig
     end
 

--- a/ext/recipes/lhist.jl
+++ b/ext/recipes/lhist.jl
@@ -1,0 +1,39 @@
+# This file is a part of LegendMakie.jl, licensed under the MIT License (MIT).
+
+function LegendMakie.lhist!(
+    h::StatsBase.Histogram{<:Any, 2};
+    watermark::Bool = true, rasterize::Bool = false, 
+    position::String = "outer top", final::Bool = true,
+    colormap::Symbol = :magma, colorscale = Makie.log10, 
+    title::AbstractString = "", xlabel = "", ylabel = "", 
+    xticks = Makie.automatic, yticks = Makie.automatic,
+    xlims = extrema(first(h.edges)), ylims = extrema(last(h.edges)),
+    kwargs...
+)
+
+    fig = Makie.current_figure()
+    g = Makie.GridLayout(fig[1,1])
+
+    #create plot
+    ax = Makie.Axis(g[1,1],
+        title = title,
+        titlesize = 18,
+        titlegap = 2,
+        titlealign = :right,
+        limits = (xlims, ylims);
+        xlabel, ylabel, xticks, yticks
+    )
+
+    hm = Makie.heatmap!(ax, h.edges..., replace(h.weights, 0 => NaN); colormap, colorscale)
+    hm.rasterize = rasterize
+    cb = Makie.Colorbar(g[1,2], hm, 
+        tickformat = values -> Makie.rich.("10", Makie.superscript.(string.(Int.(log10.(values))))),
+        ticks = exp10.(0:ceil(maximum(log10.(h.weights))))
+    )
+
+    # add watermarks
+    Makie.current_axis!(ax)
+    watermark && LegendMakie.add_watermarks!(; position, final, kwargs...)
+
+    fig
+end

--- a/ext/recipes/watermarks.jl
+++ b/ext/recipes/watermarks.jl
@@ -63,14 +63,14 @@ end
 
 
 function LegendMakie.add_watermarks!(;
-        legend_logo::Bool = false, juleana_logo::Bool = true,
+        legend_logo::Bool = false, juleana_logo::Bool = true, position::String = "outer right",
         preliminary::Bool = true, approved::Bool = false, final::Bool = false,
         kwargs...
     )
     if legend_logo
-        LegendMakie.add_legend_logo!()
+        LegendMakie.add_legend_logo!(; position)
     elseif juleana_logo
-        LegendMakie.add_juleana_logo!()
+        LegendMakie.add_juleana_logo!(; position)
     end
 
     if !final && preliminary

--- a/src/lplot.jl
+++ b/src/lplot.jl
@@ -14,6 +14,18 @@ export lplot, lplot!
 
 
 """
+    lplot(objs...)
+    lplot!(objs...)
+
+Plots `objs` via Makie in a LEGEND-specific form/style into a new histogram.
+
+"""
+function lhist end
+function lhist! end
+export lhist, lhist!
+
+
+"""
     lsavefig(filename)
 
 Saves the current figure to a file with a given `filename`.

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -82,6 +82,10 @@ using Test
             myσ(E) = sqrt(σA^2 + σB^2/E^2)
             aoe = [let _μ = myμ(E), _σ = myσ(E); (rand() < 0.2 ? -rand(Distributions.Exponential(5*_σ)) : 0) + _σ*randn() + _μ; end for E in e_cal]
 
+            # A/E vs. E 2D histogram
+            h_aoe = StatsBase.fit(StatsBase.Histogram, (e_cal, aoe), (0:0.5:3000, 0.1:5e-3:1.8))
+            @test_nowarn lhist(h_aoe, rasterize = true, title = "Test")
+
             compton_bands = collect((550:50:2350)u"keV")
             compton_window = 20u"keV"
             compton_band_peakhists = LegendSpecFits.generate_aoe_compton_bands(aoe, e_cal*u"keV", compton_bands, compton_window)


### PR DESCRIPTION
Plot recipe to plot the evolution of `A/E` histograms with normalization before/after energy correction and charge trapping correction.

```julia
e_unit = u"keV"
h_aoe = fit(Histogram, (ustrip.(e_unit, e_cal[isfinite.(aoe)]), aoe[isfinite.(aoe)]), (0:0.5:3000, 0.1:5e-3:1.8))
LegendMakie.lhist(h_aoe, rasterize = true, figsize = (670,400),
    title = get_plottitle(filekey, det, ""; additiional_type=string(aoe_type)),
    xlabel = "Energy ($e_unit)",
    ylabel = Makie.rich("A/E", Makie.subscript(" norm")),
    xticks = 0:500:3000,
    yticks = 0.25:0.25:1.75
)        
````
![image](https://github.com/user-attachments/assets/3c97d04c-7059-49b1-a14e-440ad6551ed3)

