### PR TITLE
Add `lplot!` for energy charge trapping correction

### DIFF
--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -51,6 +51,10 @@ using Test
                 @test_nowarn lplot(report_simple, cal = false)
             end
             m_cal_simple = result_simple.c
+            result_ctc, report_ctc = LegendSpecFits.ctc_energy(ecal .* m_cal_simple, rand(length(ecal)), 2614.5u"keV", (5u"keV", 5u"keV"), m_cal_simple)
+            @testset "Test energy CTC" begin
+                @test_nowarn lplot(report_ctc, figsize = (600,600), title = "Test")
+            end
             result_fit, report_fit = LegendSpecFits.fit_peaks(result_simple.peakhists, result_simple.peakstats, lines; e_unit=result_simple.unit, calib_type=:th228, m_cal_simple=m_cal_simple)
             @testset "Fit peaks for energy calibration" begin
                 @test_nowarn lplot(report_fit, figsize = (600, 400*length(report_fit)), watermark = false)


### PR DESCRIPTION
Plot recipe for the `report` returned by `LegendSpecFits.ctc_energy`.
```julia
result_ctc, report_ctc = ctc_energy(getproperty(data_ch_after_qc, e_type) .* m_cal_simple, data_ch_after_qc.qdrift, ctc_config_ch.peak, (ctc_config_ch.left_window_size, ctc_config_ch.right_window_size), m_cal_simple)

LegendMakie.lplot(report_ctc, figsize = (600,600), # xlims = (2598,2629.5),
    title = get_plottitle(filekey, det, "CTC"; additiional_type="$e_type $ctc_cal_peak"))
```
Without `xlims`:
![image](https://github.com/user-attachments/assets/41e9146e-2504-4b5f-8cc5-dbd282c5c804)

With `xlims`:
![image](https://github.com/user-attachments/assets/34c28410-7d4b-4618-ae9a-3752866a7f7b)


