### PR TITLE
Add `lplot!` for auto calibration plots

### DIFF
--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -83,6 +83,10 @@ end
             ecal = filter(x -> x <= 265_000, vcat(rand(Distributions.Exponential(70_000),97_000), 261_450 .+ 200 .* randn(2_000), 210_350 .+ 185 .* randn(500), 159_300 .+ 170 .* randn(500)))
             lines = [:Tl208DEP, :Tl208SEP, :Tl208FEP]
             energies = [1592.513, 2103.512, 2614.511]u"keV"
+            result_autocal, report_autocal = LegendSpecFits.autocal_energy(ecal, energies, α = 0.01, rtol = 2)
+            @testset "Autocal energy" begin
+                @test_nowarn LegendMakie.lplot(report_autocal, energies, title = "Test")
+            end
             result_simple, report_simple = LegendSpecFits.simple_calibration(ecal, energies, [25, 25, 35]u"keV", [25, 25, 30]u"keV", calib_type = :th228)
             @testset "Simple energy calibration" begin
                 @test_nowarn lplot(report_simple)


### PR DESCRIPTION
Plot recipe for the `report` returned by `LegendSpecFits.autocal_energy`:
```julia
result_autocal, report_autocal = autocal_energy(e_raw, raw_config_ch.th228_cal_lines)
LegendMakie.lplot(report_autocal, raw_config_ch.th228_cal_lines, figsize = (650,400), 
    title = get_plottitle(first(filekeys), det, "Calibrated DAQ Online Energy"))
```

![image](https://github.com/user-attachments/assets/9f8f9486-c50e-4041-bf6e-0aa5a1e9296c)
