### PR TITLE
Add `lplot!` for A/E optimization plot

### DIFF
--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -77,6 +77,14 @@ end
             @testset "FWHM vs. Flat-Top Time" begin
                 @test_nowarn LegendMakie.lplot(report_ft, title = "Test")
             end
+            a_grid_wl_sg = (30:32.:350)u"ns"
+            sfs = Measurements.measurement.(rand(length(a_grid_wl_sg)), NaN) .* 100u"percent" 
+            min_sf, idx = findmin(sfs)
+            wl = Measurements.measurement(a_grid_wl_sg[idx], step(a_grid_wl_sg))
+            report_wl = (; wl, min_sf, a_grid_wl_sg, sfs)
+            @testset "A/E: SEP SF vs. Window length" begin
+                @test_nowarn LegendMakie.lplot(report_wl, title = "Test")
+            end
         end
 
         @testset "Energy calibration" begin


### PR DESCRIPTION
Plot recipe for the `report` returned by `LegendSpecFits.fit_sf_wl`
```julia
result_wl, report_wl = LegendSpecFits.fit_sf_wl(dep_sep_after_qc.dep.e, dep_sep_after_qc.dep.aoe, 
    dep_sep_after_qc.sep.e, dep_sep_after_qc.sep.aoe, dsp_config_ch.a_grid_wl_sg)

LegendMakie.lplot(report_wl, title = get_plottitle(filekey, det, "SG Filter Optimization"))
```
![image](https://github.com/user-attachments/assets/fdbdf199-0835-4976-90a0-156d5e6030c1)

