### PR TITLE
Relax type constrain on keys when plotting a `Dict`

### DIFF
--- a/ext/recipes/lplot.jl
+++ b/ext/recipes/lplot.jl
@@ -595,7 +595,7 @@ end
 
 # Dict of reports (vertical alignment)
 function LegendMakie.lplot!(
-        reports::Dict{Symbol, NamedTuple}; title::AbstractString = "", 
+        reports::Dict{<:Any, NamedTuple}; title::AbstractString = "", 
         watermark::Bool = true, final::Bool = true, kwargs...
     )
 


### PR DESCRIPTION
When the `Dict` is created with `String` instead of `Symbol`, the current method fails.
This PR relaxes the type constraints on the keys of the `Dict` (but will fail if the key is not convertible to a `String`).