### PR TITLE
Improve handling of empty `additional_pts`

### DIFF
--- a/ext/LegendMakieLegendSpecFitsExt.jl
+++ b/ext/LegendMakieLegendSpecFitsExt.jl
@@ -1008,7 +1008,7 @@ module LegendMakieLegendSpecFitsExt
 
     # Dict of reports (vertical alignment)
     function LegendMakie.lplot!(
-            reports::Dict{<:Any, NamedTuple}; title::AbstractString = "", 
+            reports::AbstractDict{<:Any, NamedTuple}; title::AbstractString = "", 
             watermark::Bool = true, final::Bool = true, kwargs...
         )
 

--- a/ext/LegendMakieLegendSpecFitsExt.jl
+++ b/ext/LegendMakieLegendSpecFitsExt.jl
@@ -95,7 +95,7 @@ module LegendMakieLegendSpecFitsExt
         Makie.scatter!(p, xvalues, yvalues, marker = :circle, color = :black, label = "Data" * label_errscaling(xerrscaling, yerrscaling))
         
         # plot additional points
-        if !isempty(additional_pts)
+        if !isempty(additional_pts) && !isempty(additional_pts.x) && !isempty(additional_pts.y)
             xvalues = Measurements.value.(additional_pts.x)
             yvalues = Measurements.value.(additional_pts.y)
             Makie.errorbars!(p, xvalues, yvalues, Measurements.uncertainty.(additional_pts.x) .* xerrscaling, direction = :x, color = :black)
@@ -138,7 +138,7 @@ module LegendMakieLegendSpecFitsExt
             ax2 = Makie.Axis(g[2,1], yticks = -3:3:3, limits = (xlims,(-5,5)), xlabel = xlabel, ylabel = "Residuals (σ)")
             LegendMakie.residualplot!(ax2, (x = Measurements.value.(report.x), residuals_norm = report.gof.residuals_norm))
             # add the additional points
-            if !isempty(additional_pts)
+            if !isempty(additional_pts) && length(additional_pts.x) == length(additional_pts.residuals_norm) > 0
                 Makie.scatter!(ax2, Measurements.value.(additional_pts.x), additional_pts.residuals_norm, 
                         marker = :circle, color = :silver, strokewidth = 1, strokecolor = :black)
             end
@@ -174,7 +174,7 @@ module LegendMakieLegendSpecFitsExt
                  
         LegendMakie.lplot!(
             report[(:par, :f_fit, :x, :y, :gof)],
-            additional_pts = if !isempty(additional_pts)
+            additional_pts = if !isempty(additional_pts) && !isempty(additional_pts.µ) && !isempty(additional_pts.peaks)
                 # strip the units from the additional points
                 μ_strip = Unitful.unit(first(additional_pts.μ)) != Unitful.NoUnits ? Unitful.ustrip.(report.e_unit, additional_pts.μ) : additional_pts.μ
                 p_strip = Unitful.unit(first(additional_pts.peaks)) != Unitful.NoUnits ? Unitful.ustrip.(report.e_unit, additional_pts.peaks) : additional_pts.peaks    
@@ -200,7 +200,7 @@ module LegendMakieLegendSpecFitsExt
 
         fig = LegendMakie.lplot!(
             report[(:par, :f_fit, :x, :y, :gof)],
-            additional_pts = if !isempty(additional_pts)
+            additional_pts = if !isempty(additional_pts) && !isempty(additional_pts.peaks) && !isempty(additional_pts.fwhm)
                 fwhm_cal = report.f_fit.(Unitful.ustrip.(additional_pts.peaks))
                 (x = Unitful.ustrip.(report.e_unit, additional_pts.peaks), y = Unitful.ustrip.(report.e_unit, additional_pts.fwhm),
                     residuals_norm = (Measurements.value.(fwhm_cal .- Unitful.ustrip.(report.e_unit, additional_pts.fwhm))) ./ Measurements.uncertainty.(fwhm_cal))

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -123,12 +123,16 @@ end
             result_calib, report_calib = LegendSpecFits.fit_calibration(1, μ_fit, energies)
             @testset "Fit energy calibration" begin
                 @test_nowarn lplot(report_calib, xerrscaling=10, yerrscaling=10, additional_pts=(μ = [100_000], peaks = [1000u"keV"]), title = "Test")
+                @test_nowarn lplot(report_calib, xerrscaling=10, yerrscaling=10, additional_pts=(μ = [], peaks = []), title = "Test")
+                @test_nowarn lplot(report_calib, xerrscaling=10, yerrscaling=10, title = "Test")
             end
             f_cal_widths(x) = report_calib.f_fit(x) .* report_calib.e_unit .- first(report_calib.par)
             fwhm_fit = f_cal_widths.(getfield.(getindex.(Ref(result_fit), lines), :fwhm))
             result_fwhm, report_fwhm = LegendSpecFits.fit_fwhm(1, energies, fwhm_fit, uncertainty=true)
             @testset "FWHM energy calibration" begin
                 @test_nowarn lplot(report_fwhm, additional_pts=(peaks = [1000u"keV"], fwhm = [3.5u"keV"]), title = "Test")
+                @test_nowarn lplot(report_fwhm, additional_pts=(peaks = [], fwhm = []), title = "Test")
+                @test_nowarn lplot(report_fwhm, title = "Test")
             end
             @testset "Throw warning for wrong report types" begin
                 report_calib_faulty = NamedTuple{keys(report_calib)}((k == :type) ? (:faulty) : report_calib[k] for k in keys(report_calib))


### PR DESCRIPTION
The plot recipe for the `report` of `fit_calibration` can take `additional_pts`. 
The current plot recipe just checked whether the `NamedTuple` is entry is empty but **not** if the fields of the `NamedTuple` are empty. This resulted in an error.

```julia
lplot(report_calib, xerrscaling=10, yerrscaling=10, additional_pts = (μ = Real[], peaks = typeof(1.0u"keV")[]), title = "Test")
```
```
BoundsError: attempt to access 0-element Vector{Real} at index [1]

Stacktrace:
 [1] throw_boundserror(A::Vector{Real}, I::Tuple{Int64})
   @ Base ./essentials.jl:14
 [2] getindex
   @ ./essentials.jl:916 [inlined]
 [3] first
   @ ./abstractarray.jl:452 [inlined]
 [4] lplot!(report::@NamedTuple{par::Vector{Unitful.Quantity{Measurements.Measurement{Float64}, 𝐋^2 𝐌 𝐓^-2, Unitful.FreeUnits{(keV,), 𝐋^2 𝐌 𝐓^-2, nothing}}}, f_fit::LegendSpecFits.var"#196#203"{LegendSpecFits.var"#205#206"}, x::Vector{Measurements.Measurement{Float64}}, y::Vector{Float64}, gof::@NamedTuple{converged::Bool, pvalue::Float64, chi2min::Float64, dof::Int64, covmat::Matrix{Float64}, residuals_norm::Vector{Float64}}, e_unit::Unitful.FreeUnits{(keV,), 𝐋^2 𝐌 𝐓^-2, nothing}, type::Symbol}; additional_pts::@NamedTuple{μ::Vector{Real}, peaks::Vector{Unitful.Quantity{Float64, 𝐋^2 𝐌 𝐓^-2, Unitful.FreeUnits{(keV,), 𝐋^2 𝐌 𝐓^-2, nothing}}}}, kwargs::@Kwargs{xerrscaling::Int64, yerrscaling::Int64, title::String})
   @ LegendMakieLegendSpecFitsExt ~/LegendMakie.jl/ext/LegendMakieLegendSpecFitsExt.jl:179
 [5] lplot!
   @ ~/LegendMakie.jl/ext/LegendMakieLegendSpecFitsExt.jl:165 [inlined]
 [6] #lplot#15
   @ ~/LegendMakie.jl/ext/LegendMakieMakieExt.jl:41 [inlined]
 [7] top-level scope
   @ In[7]:3
```

This PR should fix that error.
```julia
lplot(report_calib, xerrscaling=10, yerrscaling=10, additional_pts = (μ = Real[], peaks = typeof(1.0u"keV")[]), title = "Test")
```
![image](https://github.com/user-attachments/assets/8975f7bd-3707-46c2-853b-f616f3adce1b)