### PR TITLE
Add production name to plot by default

### DIFF
--- a/ext/recipes/watermarks.jl
+++ b/ext/recipes/watermarks.jl
@@ -61,10 +61,17 @@ function LegendMakie.add_text!(text::AbstractString)
     fig
 end
 
+function LegendMakie.add_production!(prodname::AbstractString; fontsize::Real = 7)
+    fig = Makie.current_figure()
+    ax = Makie.current_axis()
+    axright, axtop = ax.scene.viewport[].origin .+ ax.scene.viewport[].widths .* 0.995
+    Makie.text!(fig.scene, prodname; fontsize, position = (axright, axtop), align = (:right, :top))
+    fig
+end
 
 function LegendMakie.add_watermarks!(;
         legend_logo::Bool = false, juleana_logo::Bool = true, position::String = "outer right",
-        preliminary::Bool = true, approved::Bool = false, final::Bool = false,
+        preliminary::Bool = true, approved::Bool = false, final::Bool = false, production::Bool = true,
         kwargs...
     )
     if legend_logo
@@ -77,6 +84,11 @@ function LegendMakie.add_watermarks!(;
         LegendMakie.add_text!("PRELIMINARY")
     elseif !final && !approved
         LegendMakie.add_text!("INTERNAL USE ONLY")
+    end
+
+    if production && haskey(ENV, "LEGEND_DATA_CONFIG")
+        prodname = basename(dirname(last(split(ENV["LEGEND_DATA_CONFIG"], ":"))))
+        LegendMakie.add_production!(prodname)
     end
 
     Makie.current_figure()

--- a/src/lplot.jl
+++ b/src/lplot.jl
@@ -48,3 +48,4 @@ function add_legend_logo! end
 function add_juleana_logo! end
 function add_text! end
 function add_watermarks! end
+function add_production! end


### PR DESCRIPTION
Fix #45.

Note that the production is plotted by default if the environment variable `LEGEND_DATA_CONFIG` is set.
You can omit plotting the production by setting a keyword `production = false`.

MWE:
```julia
using Makie, LegendMakie, CairoMakie
ENV["LEGEND_DATA_CONFIG"] = "/some/directory/jl-vX.Y.Z/config.json"
fig = Makie.Figure()
ax = Makie.Axis(fig[1,1], title = "This is an extremely long plot title that spans over the whole top")
Makie.lines!(ax, rand(10), rand(10), label = "Some text")
Makie.axislegend(ax, position = :rt)
LegendMakie.add_watermarks!(final = true)
```
![image](https://github.com/user-attachments/assets/da5dd26a-97ed-44f0-996b-c72d50669807)

