### PR TITLE
Add `qc_window_cut` recipe

### DIFF
--- a/ext/LegendMakieLegendSpecFitsExt.jl
+++ b/ext/LegendMakieLegendSpecFitsExt.jl
@@ -21,7 +21,7 @@ module LegendMakieLegendSpecFitsExt
     end
 
     function round_wo_units end
-    round_wo_units(x::Real; digits=2) = round(x, digits=digits)
+    round_wo_units(x::Real; digits=2) = round(x, sigdigits=digits)
     round_wo_units(x::Unitful.Quantity; kwargs...) = round_wo_units(Unitful.ustrip(x); kwargs...)*Unitful.unit(x)
     function round_wo_units(m::Measurements.Measurement; digits::Int=2)
         # copied from the truncated_print function in Measurements.jl

--- a/ext/LegendMakieLegendSpecFitsExt.jl
+++ b/ext/LegendMakieLegendSpecFitsExt.jl
@@ -21,7 +21,7 @@ module LegendMakieLegendSpecFitsExt
     end
 
     function round_wo_units(x::Unitful.RealOrRealQuantity; digits::Int=2)
-        Unitful.unit(x) == Unitful.NoUnits ? round(x; digits) : round(Unitful.unit(x), x; digits)
+        Unitful.unit(x) == Unitful.NoUnits ? round(x; sigdigits=digits) : round(Unitful.unit(x), x; sigdigits=digits)
     end
 
     # function to compose labels when errorbars are scaled
@@ -434,18 +434,20 @@ module LegendMakieLegendSpecFitsExt
     # plot report from singlefits, e.g. fit_single_trunc_gauss
     function LegendMakie.lplot!(
             report::NamedTuple{(:f_fit, :h, :μ, :σ, :gof)};
-            title::AbstractString = "", titlesize = 18, show_residuals::Bool = true,
-            ylims = (0,nothing), xlabel = "", xticks = Makie.WilkinsonTicks(6, k_min=5), digits = 2,
+            title::AbstractString = "", titlesize = 18, 
+            show_residuals::Bool = true, row::Int = 1, col::Int = 1,
+            ylims = (minimum(filter(x -> x > 0, report.h.weights)),nothing), xlabel = "", xticks = Makie.WilkinsonTicks(6, k_min=5), digits = 2,
             xlims = Unitful.ustrip.(Measurements.value.((report.μ - 5*report.σ, report.μ + 5*report.σ))), 
+            yscale = Makie.log10,
             legend_position = :lt, watermark::Bool = true, final::Bool = !isempty(title), kwargs...
         )
 
         fig = Makie.current_figure()
         
-        g = Makie.GridLayout(fig[1,1])
+        g = Makie.GridLayout(fig[row,col])
         ax = Makie.Axis(g[1,1], 
             titlefont = :bold, limits = (xlims, ylims), ylabel = "Normalized Counts";
-            title, xlabel, xticks, titlesize 
+            yscale, title, xlabel, xticks, titlesize 
         )
         
         # Create histogram
@@ -483,6 +485,32 @@ module LegendMakieLegendSpecFitsExt
         Makie.current_axis!(ax)
         watermark && LegendMakie.add_watermarks!(; final, kwargs...)
         
+        fig
+    end
+
+    # plot QC cut window fits
+    function LegendMakie.lplot!(report::NamedTuple{(:f_fit, :h, :μ, :σ, :gof, :low_cut, :high_cut)}; show_residuals::Bool = true, legend_position = :lt, kwargs...)
+        n_σ = round_wo_units(Measurements.value((report.µ - report.low_cut) / report.σ), digits=1)
+        # plot simpel gaussian fit
+        fig = LegendMakie.lplot!(
+            NamedTuple{(:f_fit, :h, :μ, :σ, :gof)}(report); 
+            xlims = Unitful.ustrip.(Measurements.value.((report.μ - 2.5*n_σ*report.σ, report.μ + 1.5*n_σ*report.σ))),
+            legend_position=:none, show_residuals = show_residuals,
+            kwargs...)
+        
+        # get axis and plot the cut window
+        ax = if !isempty(report.gof) && show_residuals
+            fig.content[end-1]
+        else
+            fig.content[end]
+        end
+        Makie.current_axis!(ax)
+
+        Makie.vspan!(ax, Unitful.ustrip.(Measurements.value.((report.low_cut, report.high_cut)))..., color=LegendMakie.CoaxGreen, alpha=0.05, label=nothing)
+        Makie.vlines!(ax, Unitful.ustrip.(Measurements.value.([report.low_cut, report.high_cut])), linewidth=2.5, color=LegendMakie.CoaxGreen, label="$(n_σ)σ cut window")
+        if legend_position != :none 
+            Makie.axislegend(ax, position = legend_position)
+        end
         fig
     end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -20,6 +20,6 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Documenter = "1"
-LegendSpecFits = "0.4"
+LegendSpecFits = "0.4.3"
 LegendTestData = "0.2"
 Makie = "0.22"

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -63,6 +63,23 @@ end
 
             result, report = LegendSpecFits.fit_single_trunc_gauss(randn(10000), uncertainty = false)
             @test_nowarn lplot(report, xlabel = "Test")
+
+            result, report = LegendSpecFits.get_centered_gaussian_window_cut(randn(10000), -10.0, 10.0, 1.0; n_bins = -1)
+            @test_nowarn lplot(report, xlabel = "Test")
+        end
+
+        @testset "QC" begin
+            t = Table(x1 = randn(1000000), x2 = randn(1000000))
+            config = PropDict(
+                :x1 => PropDict(:min => -10.0, :max => 10.0, :sigma => 2.0,
+                    :kwargs => PropDict(:relative_cut => 0.01, :n_bins => -1, :fixed_center => false, :left => false)
+                ),
+                :x2 => PropDict(:min => -10.0, :max => 10.0, :sigma => 2.0,
+                    :kwargs => PropDict(:relative_cut => 0.01, :n_bins => -1, :fixed_center => false, :left => true)
+                ))
+            
+            result, report = qc_window_cut(t, config, (:x1, :x2))
+            @test_nowarn lplot(report, title = "Test")
         end
 
         @testset "Filter optimization" begin

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -69,16 +69,16 @@ end
         end
 
         @testset "QC" begin
-            t = Table(x1 = randn(1000000), x2 = randn(1000000))
-            config = PropDict(
-                :x1 => PropDict(:min => -10.0, :max => 10.0, :sigma => 2.0,
-                    :kwargs => PropDict(:relative_cut => 0.01, :n_bins => -1, :fixed_center => false, :left => false)
+            t = TypedTables.Table(x1 = randn(1000000), x2 = randn(1000000))
+            config = PropDicts.PropDict(
+                :x1 => PropDicts.PropDict(:min => -10.0, :max => 10.0, :sigma => 2.0,
+                    :kwargs => PropDicts.PropDict(:relative_cut => 0.01, :n_bins => -1, :fixed_center => false, :left => false)
                 ),
-                :x2 => PropDict(:min => -10.0, :max => 10.0, :sigma => 2.0,
-                    :kwargs => PropDict(:relative_cut => 0.01, :n_bins => -1, :fixed_center => false, :left => true)
+                :x2 => PropDicts.PropDict(:min => -10.0, :max => 10.0, :sigma => 2.0,
+                    :kwargs => PropDicts.PropDict(:relative_cut => 0.01, :n_bins => -1, :fixed_center => false, :left => true)
                 ))
             
-            result, report = qc_window_cut(t, config, (:x1, :x2))
+            result, report = LegendSpecFits.qc_window_cut(t, config, (:x1, :x2))
             @test_nowarn lplot(report, title = "Test")
         end
 


### PR DESCRIPTION
This PR adds the `qc_window_cut` recipe as well as some adaptions to the `single_fit` recipe to have more control over the individual fits. Tests will likely fail until `LegendSpecFits` will be released and updated after merge of [PR#159](https://github.com/legend-exp/LegendSpecFits.jl/pull/159)
Example of QC fits: 
<img width="1200" height="2400" alt="qc_window_cut_example" src="https://github.com/user-attachments/assets/5ea100ac-5af5-411c-a99b-f94ca2e7263d" />

CC @verenaaur 