### PR TITLE
drop ChannelId waveformplotting support

### DIFF
--- a/ext/LegendMakieLegendDataManagementExt.jl
+++ b/ext/LegendMakieLegendDataManagementExt.jl
@@ -118,12 +118,11 @@ module LegendMakieLegendDataManagementExt
 
 
     function LegendMakie.lplot!(
-            data::LegendDataManagement.LegendData, fk::LegendDataManagement.FileKey, ts::Unitful.Time{<:Real}, ch::Union{<:LegendDataManagement.ChannelIdLike, <:LegendDataManagement.DetectorIdLike}; 
+            data::LegendDataManagement.LegendData, fk::LegendDataManagement.FileKey, ts::Unitful.Time{<:Real}, det::LegendDataManagement.DetectorIdLike; 
             plot_tier = LegendDataManagement.DataTier(:raw), plot_waveform = [:waveform_presummed], show_unixtime = false, xunit::Unitful.Units = u"µs", 
             xlims = nothing, show_title::Bool = true, show_label::Bool = true, watermark::Bool = true, final::Bool = true
         )
-
-        det = Base.get_extension(LegendDataManagement, :LegendDataManagementLegendHDF5IOExt)._get_detectorid(data, fk, ch)
+        det = LegendDataManagement.DetectorId(det)  # convert to DetectorId if necessary
         
         raw = LegendDataManagement.read_ldata(data, plot_tier, fk, det)
         idx = findfirst(isequal(ts), raw.timestamp)
@@ -245,9 +244,9 @@ module LegendMakieLegendDataManagementExt
     end
 
 
-    function LegendMakie.lplot!(data::LegendDataManagement.LegendData, ts::Unitful.Time{<:Real}, ch::Union{<:LegendDataManagement.ChannelIdLike, <:LegendDataManagement.DetectorIdLike}; kwargs...)
+    function LegendMakie.lplot!(data::LegendDataManagement.LegendData, ts::Unitful.Time{<:Real}, det::LegendDataManagement.DetectorIdLike; kwargs...)
         fk = LegendDataManagement.find_filekey(data, ts)
-        det = Base.get_extension(LegendDataManagement, :LegendDataManagementLegendHDF5IOExt)._get_detectorid(data, fk, ch)
+        det = LegendDataManagement.DetectorId(det)  # convert to DetectorId if necessary
         LegendMakie.lplot!(data, fk, ts, det; kwargs...)
     end
 

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -78,7 +78,7 @@ end
                     :kwargs => PropDicts.PropDict(:relative_cut => 0.01, :n_bins => -1, :fixed_center => false, :left => true)
                 ))
             
-            result, report = LegendSpecFits.qc_window_cut(t, config, (:x1, :x2))
+            result, report = LegendSpecFits.qc_window_cut(t, config)
             @test_nowarn lplot(report, figsize = (600,900), title = "Test")
         end
 

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -327,14 +327,6 @@ end
             @test_nowarn lplot(data, t_phy, det, figsize = (800,380), xlims = (0,128), show_label = false)
         end
 
-        # Old syntax
-        ch = LegendDataManagement.ChannelId(1234568)
-        @testset "Channel plots" begin 
-            @test_nowarn lplot(data, t_cal, ch, figsize = (800,380), xlims = (0,128))
-            @test_throws ArgumentError lplot(data, t_cal .+ 1u"s", ch, figsize = (800,380), xlims = (0,128))
-            @test_nowarn lplot(data, t_phy, ch, figsize = (800,380), xlims = (0,128), show_label = false)
-        end
-        
         # remove test repository
         isdir(testdir) && rm(testdir, force = true, recursive = true)
     end


### PR DESCRIPTION
As mentioned in https://github.com/legend-exp/LegendDataManagement.jl/pull/180, we decided to drop the ChannelId support in LegendDataManagement. As a consequence we also need to drop that here in the LegendMakieLegendDataManagementExt.