### PR TITLE
Empty figure in lsavefig() after saving so the Garbage Collector can free it

### DIFF
--- a/ext/LegendMakieMakieExt.jl
+++ b/ext/LegendMakieMakieExt.jl
@@ -58,7 +58,11 @@ module LegendMakieMakieExt
         LegendMakie.lsavefig(fig, name; kwargs...)
     end
 
-    function LegendMakie.lsavefig(fig::Makie.Figure, name::AbstractString; kwargs...)
-        FileIO.save(name, fig; kwargs...)
+    # Makie keeps every figure reachable through listeners on the global theme, so a long
+    # session leaks ~90 MB per saved figure; empty!(fig) after saving disconnects them.
+    function LegendMakie.lsavefig(fig::Makie.Figure, name::AbstractString; cleanup::Bool = true, kwargs...)
+        ret = FileIO.save(name, fig; kwargs...)
+        cleanup && Base.empty!(fig)
+        return ret
     end
 end

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -35,6 +35,21 @@ using Test
             rm(fn)
         end
     end
+    @testset "cleanup after saving" begin
+        # saving empties the figure by default (breaks the global-theme references that
+        # otherwise keep every saved figure alive); cleanup = false keeps it intact
+        fig = Makie.Figure()
+        Makie.Axis(fig[1, 1]); Makie.Label(fig[2, 1], "keep")
+        @test length(fig.content) == 2
+        lsavefig(fig, "cleanup.png")
+        @test isempty(fig.content)
+        rm("cleanup.png")
+        fig2 = Makie.Figure()
+        Makie.Axis(fig2[1, 1])
+        lsavefig(fig2, "nocleanup.png"; cleanup = false)
+        @test length(fig2.content) == 1
+        rm("nocleanup.png")
+    end
 end
 
 @testset "lplot" begin


### PR DESCRIPTION
While processing the ecal processor over several runs I always ran into OOM kills on slurm. The processor creates a lot of plots and I noticed that a worker that processes one detector in one run keeps all saved plots in RAM forever. The memory grows linearly with the number of processed runs/detectors.

The reason is that figure elements register listeners on the observables of Makies global theme with around 250 listeners per figure in Makie. Each listener is a reference from the theme to the figure content and the theme lives as long as the process. The Garbage collector can only free objects that are no longer reachable, so the axes, plots and data of every saved figure stay reachable and are never freed, even if the PNG is long on disk and the fig variable is gone.

Fix: lsavefig calls empty!(fig) right after FileIO.save. That removes the figure content and disconnects the theme listeners,so the  Garbage Collector can free everything. cleanup = false argument still keeps the old behaviour. 

Minimal Code example (generated by Claude Fable 5): 
```
using LegendMakie, CairoMakie, Makie
import LegendMakie: lsavefig

function probe(; cleanup::Bool)
    payload = rand(1000, 1000)                 # 8 MB of "science data"
    fig = Figure(); ax = Axis(fig[1, 1]); heatmap!(ax, payload)
    lsavefig(fig, "leak.png"; cleanup)
    w_ax, w_data = WeakRef(ax), WeakRef(payload)
    fig = ax = payload = nothing
    Figure()                                   # displace the current-figure reference
    GC.gc(); GC.gc(); GC.gc()
    freed(w) = w.value === nothing ? "freed" : "STILL IN RAM"
    return "axis: $(freed(w_ax)) | data: $(freed(w_data))"
end
println("cleanup = false (old behaviour):  ", probe(cleanup = false))
println("cleanup = true  (this PR):        ", probe(cleanup = true))
```
