### PR TITLE
Stability plots

### DIFF
--- a/ext/LegendMakieMakieExt.jl
+++ b/ext/LegendMakieMakieExt.jl
@@ -61,4 +61,131 @@ module LegendMakieMakieExt
     function LegendMakie.lsavefig(fig::Makie.Figure, name::AbstractString; kwargs...)
         FileIO.save(name, fig; kwargs...)
     end
+
+
+    # ---------------------------------------------------------------------------
+    # Generic time-vs-quantity stability heatmap. Covers time-vs-baseline,
+    # time-vs-baseline-σ, time-vs-E_cusp, and the pulser-triggered E_cusp subset
+    # — construct with new data, no new lplot method needed.
+    # ---------------------------------------------------------------------------
+    function LegendMakie.lplot(report::LegendMakie.TimeSeriesHeatmapReport)
+        finite = isfinite.(report.time) .&& isfinite.(report.y)
+        time, y = report.time[finite], report.y[finite]
+        isempty(time) && throw(ArgumentError(
+            "no finite (time, y) pairs to plot for \"$(report.title)\""
+        ))
+
+        yl = something(report.ylims, (minimum(y), maximum(y)))
+
+        xedges = range(minimum(time), maximum(time), length = report.nbins + 1)
+        yedges = range(yl[1], yl[2], length = report.nbins + 1)
+        h = StatsBase.fit(
+            StatsBase.Histogram,
+            (time, y),
+            (collect(xedges), collect(yedges)),
+        )
+        xc = 0.5 .* (h.edges[1][1:end-1] .+ h.edges[1][2:end])
+        yc = 0.5 .* (h.edges[2][1:end-1] .+ h.edges[2][2:end])
+        zlog = log10.(Float64.(h.weights) .+ 1)
+
+        fig = Makie.Figure(size = (900, 600))
+        ax = Makie.Axis(
+            fig[1, 1],
+            xlabel = "Time (s)",
+            ylabel = report.ylabel,
+            title = report.title,
+        )
+        hm = Makie.heatmap!(ax, xc, yc, zlog; colormap = :viridis)
+        Makie.Colorbar(fig[1, 2], hm, label = "log10(counts + 1)")
+        return fig
+    end
+
+    # ---------------------------------------------------------------------------
+    # 1D log-scale energy histogram (E_cusp distribution).
+    # ---------------------------------------------------------------------------
+    function LegendMakie.lplot(report::LegendMakie.EnergyHistReport)
+        e = filter(isfinite, report.e)
+        h1d = StatsBase.fit(StatsBase.Histogram, e, report.binning)
+        counts = Float64.(h1d.weights)
+        counts[counts .== 0] .= NaN
+        edges = h1d.edges[1]
+
+        xstairs, ystairs = Float64[], Float64[]
+        for i in eachindex(counts)
+            push!(xstairs, edges[i], edges[i+1])
+            push!(ystairs, counts[i], counts[i])
+        end
+
+        fig = Makie.Figure(size = (900, 400))
+        ax = Makie.Axis(
+            fig[1, 1],
+            xlabel = report.xlabel,
+            ylabel = "Counts",
+            yscale = log10,
+            title = report.title,
+        )
+        Makie.lines!(ax, xstairs, ystairs; color = :blue, linewidth = 2)
+        return fig
+    end
+
+    # ---------------------------------------------------------------------------
+    # Pulser-based gain stability (ΔE vs time, pulser overlaid with E_cusp).
+    # ---------------------------------------------------------------------------
+
+    # Rolling mean/std — private helper for this recipe only.
+    function _rollstats(x, N_smooth)
+        n, h = length(x), div(N_smooth, 2)
+        μ, σ = similar(x), similar(x)
+        @inbounds for i in 1:n
+            lo, hi = max(1, i - h), min(n, i + h)
+            w = @view x[lo:hi]
+            μ[i] = StatsBase.mean(w)
+            σ[i] = StatsBase.std(w)
+        end
+        return μ, σ
+    end
+
+    function LegendMakie.lplot(report::LegendMakie.GainStabilityReport)
+        time, e_cusp, e_puls = report.time, report.e_cusp, report.e_pulser
+        e0, ec0 = e_puls[1], e_cusp[1]
+
+        e_pct  = (e_puls .- e0)  ./ e0  .* 100
+        ec_pct = (e_cusp .- ec0) ./ ec0 .* 100
+
+        n0 = min(report.n_ref, length(e_pct))
+        e_pct  .-= StatsBase.median(e_pct[1:n0])
+        ec_pct .-= StatsBase.median(ec_pct[1:n0])
+
+        e_keV  = e_pct  ./ 100 .* report.Qbb
+        ec_keV = ec_pct ./ 100 .* report.Qbb
+
+        t0 = StatsBase.median(time[1:n0])
+        time_shifted = time .- t0
+
+        e_mean,  e_std  = _rollstats(e_keV, report.n_smooth)
+        ec_mean, ec_std = _rollstats(ec_keV, report.n_smooth)
+
+        fig = Makie.Figure(size = (1000, 450), backgroundcolor = :white)
+        ax = Makie.Axis(
+            fig[1, 1];
+            xlabel = "Time (s)",
+            ylabel = "ΔE (keV)",
+            title = report.title,
+            xgridvisible = true,
+            ygridvisible = true,
+            xgridstyle = :dash,
+            ygridstyle = :dash,
+        )
+        Makie.ylims!(ax, -8, 8)
+
+        # bands first so the mean lines sit on top
+        Makie.band!(ax, time_shifted, e_mean .- e_std,  e_mean .+ e_std;  color = (:blue, 0.2))
+        Makie.band!(ax, time_shifted, ec_mean .- ec_std, ec_mean .+ ec_std; color = (:red, 0.2))
+
+        Makie.lines!(ax, time_shifted, e_mean;  color = :blue, linewidth = 2, label = "Pulser")
+        Makie.lines!(ax, time_shifted, ec_mean; color = :red,  linewidth = 2, label = "E_cusp")
+
+        Makie.axislegend(ax; position = :rt)
+        return fig
+    end
 end

--- a/src/LegendMakie.jl
+++ b/src/LegendMakie.jl
@@ -10,6 +10,7 @@ module LegendMakie
     include("utils.jl")
     include("lplot.jl")
     include("register_extdeps.jl")
+    include("plotting_structs.jl")
 
     function __init__()
         _register_extension_deps(
@@ -21,4 +22,5 @@ module LegendMakie
         )
     end
 
+    export TimeSeriesHeatmapReport, EnergyHistReport, GainStabilityReport
 end # module

--- a/src/plotting_structs.jl
+++ b/src/plotting_structs.jl
@@ -1,0 +1,57 @@
+struct TimeSeriesHeatmapReport
+    time::Vector{Float64}
+    y::Vector{Float64}
+    ylabel::String
+    title::String
+    ylims::Union{Nothing, Tuple{Float64,Float64}}
+    nbins::Int
+end
+
+TimeSeriesHeatmapReport(time, y; ylabel, title, ylims = nothing, nbins = 600) =
+    TimeSeriesHeatmapReport(
+        collect(float.(time)),
+        collect(float.(y)),
+        ylabel,
+        title,
+        ylims,
+        nbins
+    )
+
+
+struct EnergyHistReport
+    e::Vector{Float64}
+    xlabel::String
+    title::String
+    binning::AbstractRange
+end
+
+EnergyHistReport(e; xlabel, title, binning = 0:1000:6e5) =
+    EnergyHistReport(collect(float.(e)), xlabel, title, binning)
+
+
+struct GainStabilityReport
+    time::Vector{Float64}
+    e_cusp::Vector{Float64}
+    e_pulser::Vector{Float64}
+    Qbb::Float64
+    n_ref::Int
+    n_smooth::Int
+    title::String
+end
+
+GainStabilityReport(
+    time, e_cusp, e_pulser;
+    Qbb = 2039.0,
+    n_ref = 500,
+    n_smooth = 201,
+    title
+) =
+    GainStabilityReport(
+        collect(float.(time)),
+        collect(float.(e_cusp)),
+        collect(float.(e_pulser)),
+        Qbb,
+        n_ref,
+        n_smooth,
+        title
+    )

--- a/test/test_lplot.jl
+++ b/test/test_lplot.jl
@@ -56,6 +56,39 @@ end
         @test_throws ArgumentError LegendMakie.add_watermarks!(position = "Test")
     end
 
+    @testset "Stability plots" begin
+        @testset "Time-series heatmap" begin
+            time = collect(0.0:9.0)
+            values = [0.1, 0.2, NaN, 0.4, 0.5, Inf, 0.7, 0.8, 0.9, 1.0]
+
+            report = TimeSeriesHeatmapReport(time, values; ylabel = "Baseline (ADC)", title = "Baseline stability", nbins = 10)
+            @test_nowarn lplot(report)
+
+            report_with_limits = TimeSeriesHeatmapReport(time, values; ylabel = "Baseline σ (ADC)", title = "Baseline σ stability", ylims = (0.0, 1.2), nbins = 10)
+            @test_nowarn lplot(report_with_limits)
+
+            invalid_report = TimeSeriesHeatmapReport([NaN, Inf], [NaN, Inf]; ylabel = "E_cusp (ADC)", title = "Invalid stability data", nbins = 10)
+            @test_throws ArgumentError lplot(invalid_report)
+        end
+
+        @testset "Energy histogram" begin
+            report = EnergyHistReport([100.0, 150.0, 900.0, 1_100.0, NaN, Inf]; xlabel = "E_cusp (ADC)", title = "E_cusp distribution", binning = 0.0:250.0:1_500.0)
+            @test_nowarn lplot(report)
+        end
+
+        @testset "Gain stability" begin
+            time = collect(0.0:10.0:90.0)
+            e_pulser = 1_000.0 .+ range(0.0, 0.9, length = length(time))
+            e_cusp = 2_000.0 .+ range(0.0, 1.2, length = length(time))
+            report = GainStabilityReport(time, e_cusp, e_pulser; Qbb = 2_039.0, n_ref = 4, n_smooth = 3, title = "Pulser gain stability")
+            @test_nowarn lplot(report)
+
+            # n_ref may exceed the number of samples and is truncated internally.
+            short_report = GainStabilityReport(time[1:3], e_cusp[1:3], e_pulser[1:3]; n_ref = 500, n_smooth = 3, title = "Short pulser gain stability")
+            @test_nowarn lplot(short_report)
+        end
+    end
+
     @testset "Test LegendSpecFits reports" begin
         @testset "Singlefits" begin
             result, report = LegendSpecFits.fit_single_trunc_gauss(randn(10000), (low = -4.0, high = 4.0, max = NaN))


### PR DESCRIPTION
Hi,
this PR adds the recipes for a few stability plots, that i want to add into a new stability plot processor.
Usually we plot a report with `lplot`, but my data stability plots i want to plot `dsp` data.
So how i chose to implement the new recipes was to add new structs, that can be called in the processor to get the data into the right format for the plot recipe